### PR TITLE
Fix error when reading classes woven by AspectJ

### DIFF
--- a/src/main/java/com/chrisnewland/classact/ClassAct.java
+++ b/src/main/java/com/chrisnewland/classact/ClassAct.java
@@ -560,7 +560,15 @@ public class ClassAct
     {
         debug("processSingleAttribute " + attributeName + " attributeLength " + attributeLength);
 
-        AttributeType attributeType = AttributeType.valueOf(attributeName);
+        AttributeType attributeType;
+        try 
+        {
+            attributeType = AttributeType.valueOf(attributeName);
+        } 
+        catch (IllegalArgumentException e)
+        {
+            attributeType = AttributeType.Unknown;
+        }
 
         switch (attributeType)
         {

--- a/src/main/java/com/chrisnewland/classact/model/AttributeType.java
+++ b/src/main/java/com/chrisnewland/classact/model/AttributeType.java
@@ -31,5 +31,6 @@ public enum AttributeType
 	NestHost,
 	NestMembers,
 	Record,
-	PermittedSubclasses
+	PermittedSubclasses,
+	Unknown
 }


### PR DESCRIPTION
I have tried out byte-me.dev with a class that was woven by AspectJ. 
Obviously AspectJ adds an unknown attribute to the .class file which results in
`Could not process uploaded class file: No enum constant com.chrisnewland.classact.model.AttributeType.org.aspectj.weaver.WeaverVersion`

This is a small fix that solves this issue (I guess?)